### PR TITLE
Save figures for individual panel plots

### DIFF
--- a/acme_diags/acme_parameter.py
+++ b/acme_diags/acme_parameter.py
@@ -26,6 +26,7 @@ class ACMEParameter(cdp.cdp_parameter.CDPParameter):
         # self.backend = 'vcs'  # No default backend for now, user needs to specify which one
         self.save_netcdf = False
         self.output_format = ['png']
+        self.output_format_subplot = []
         self.canvas_size_w = 1212
         self.canvas_size_h = 1628
         self.figsize = [8.5, 11.0]

--- a/acme_diags/acme_parser.py
+++ b/acme_diags/acme_parser.py
@@ -141,6 +141,14 @@ class ACMEParser(cdp.cdp_parser.CDPParser):
             required=False)
 
         self.add_argument(
+            '--output_format_subplot',
+            nargs='+',
+            dest='output_format_subplot',
+            help="What output format the individual subplots should be saved in (leave empty for no subplots)."
+                 + "Possible values are: ['png', 'pdf', 'svg'].",
+            required=False)
+
+        self.add_argument(
             '--canvas_size_w',
             type=int,
             dest='canvas_size_w',

--- a/acme_diags/plot/cartopy/cosp_histogram_plot.py
+++ b/acme_diags/plot/cartopy/cosp_histogram_plot.py
@@ -12,10 +12,15 @@ from acme_diags.plot import get_colormap
 plotTitle = {'fontsize': 11.5}
 plotSideTitle = {'fontsize': 9.5}
 
-panel = [(0.1691, 0.6810, 0.6465, 0.2258),
-         (0.1691, 0.3961, 0.6465, 0.2258),
-         (0.1691, 0.1112, 0.6465, 0.2258),
+# Position and sizes of subplot axes in page coordinates (0 to 1)
+panel = [(0.1691, 0.6810, 0.6465, 0.2150),
+         (0.1691, 0.3961, 0.6465, 0.2150),
+         (0.1691, 0.1112, 0.6465, 0.2150),
          ]
+
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+border = (-0.10, -0.05, 0.13, 0.033)
 
 
 def get_ax_size(fig, ax):
@@ -166,3 +171,24 @@ def plot(reference, test, diff, _, parameter):
         plt.savefig(fnm + '.' + f)
         _chown(fnm + '.' + f, parameter.user)
         print('Plot saved in: ' + fnm + '.' + f)
+
+    # Save individual subplots
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(get_output_dir(
+            parameter.current_set, parameter), parameter.output_file)
+        page = fig.get_size_inches()
+        i = 0
+        for p in panel:
+            # Extent of subplot
+            subpage = np.array(p).reshape(2,2)
+            subpage[1,:] = subpage[0,:] + subpage[1,:]
+            subpage = subpage + np.array(border).reshape(2,2)
+            subpage = list(((subpage)*page).flatten())
+            extent = matplotlib.transforms.Bbox.from_extents(*subpage)
+            # Save suplot
+            fname = fnm + '.%i.' %(i) + f
+            plt.savefig(fname, bbox_inches=extent)
+            _chown(fname, parameter.user)
+            print('Sub-plot saved in: ' + fname)
+            i += 1
+

--- a/acme_diags/plot/cartopy/lat_lon_plot.py
+++ b/acme_diags/plot/cartopy/lat_lon_plot.py
@@ -16,10 +16,15 @@ from acme_diags.plot import get_colormap
 plotTitle = {'fontsize': 11.5}
 plotSideTitle = {'fontsize': 9.5}
 
+# Position and sizes of subplot axes in page coordinates (0 to 1)
 panel = [(0.1691, 0.6810, 0.6465, 0.2258),
          (0.1691, 0.3961, 0.6465, 0.2258),
          (0.1691, 0.1112, 0.6465, 0.2258),
          ]
+
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+border = (-0.06, -0.03, 0.13, 0.03)
 
 
 def add_cyclic(var):
@@ -161,3 +166,24 @@ def plot(reference, test, diff, metrics_dict, parameter):
         plt.savefig(fnm + '.' + f)
         _chown(fnm + '.' + f, parameter.user)
         print('Plot saved in: ' + fnm + '.' + f)
+
+    # Save individual subplots
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(get_output_dir(
+            parameter.current_set, parameter), parameter.output_file)
+        page = fig.get_size_inches()
+        i = 0
+        for p in panel:
+            # Extent of subplot
+            subpage = np.array(p).reshape(2,2)
+            subpage[1,:] = subpage[0,:] + subpage[1,:]
+            subpage = subpage + np.array(border).reshape(2,2)
+            subpage = list(((subpage)*page).flatten())
+            extent = matplotlib.transforms.Bbox.from_extents(*subpage)
+            # Save suplot
+            fname = fnm + '.%i.' %(i) + f
+            plt.savefig(fname, bbox_inches=extent)
+            _chown(fname, parameter.user)
+            print('Sub-plot saved in: ' + fname)
+            i += 1
+

--- a/acme_diags/plot/cartopy/polar_plot.py
+++ b/acme_diags/plot/cartopy/polar_plot.py
@@ -15,10 +15,15 @@ from acme_diags.plot import get_colormap
 plotTitle = {'fontsize': 11.5}
 plotSideTitle = {'fontsize': 9.0}
 
+# Position and sizes of subplot axes in page coordinates (0 to 1)
 panel = [(0.27, 0.65, 0.3235, 0.25),
          (0.27, 0.35, 0.3235, 0.25),
          (0.27, 0.05, 0.3235, 0.25),
          ]
+
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+border = (-0.02, -0.01, 0.14, 0.04)
 
 
 def add_cyclic(var):
@@ -179,3 +184,23 @@ def plot(reference, test, diff, metrics_dict, parameter):
         plt.savefig(fnm + '.' + f)
         _chown(fnm + '.' + f, parameter.user)
         print('Plot saved in: ' + fnm + '.' + f)
+
+    # Save individual subplots
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(get_output_dir(
+            parameter.current_set, parameter), parameter.output_file)
+        page = fig.get_size_inches()
+        i = 0
+        for p in panel:
+            # Extent of subplot
+            subpage = np.array(p).reshape(2,2)
+            subpage[1,:] = subpage[0,:] + subpage[1,:]
+            subpage = subpage + np.array(border).reshape(2,2)
+            subpage = list(((subpage)*page).flatten())
+            extent = matplotlib.transforms.Bbox.from_extents(*subpage)
+            # Save suplot
+            fname = fnm + '.%i.' %(i) + f
+            plt.savefig(fname, bbox_inches=extent)
+            _chown(fname, parameter.user)
+            print('Sub-plot saved in: ' + fname)
+            i += 1

--- a/acme_diags/plot/cartopy/zonal_mean_2d_plot.py
+++ b/acme_diags/plot/cartopy/zonal_mean_2d_plot.py
@@ -14,10 +14,15 @@ from acme_diags.plot import get_colormap
 plotTitle = {'fontsize': 11.5}
 plotSideTitle = {'fontsize': 9.5}
 
+# Position and sizes of subplot axes in page coordinates (0 to 1)
 panel = [(0.1691, 0.6810, 0.6465, 0.2258),
          (0.1691, 0.3961, 0.6465, 0.2258),
          (0.1691, 0.1112, 0.6465, 0.2258),
          ]
+
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+border = (-0.06, -0.03, 0.13, 0.03)
 
 
 def add_cyclic(var):
@@ -167,3 +172,24 @@ def plot(reference, test, diff, metrics_dict, parameter):
         plt.savefig(fnm + '.' + f)
         _chown(fnm + '.' + f, parameter.user)
         print('Plot saved in: ' + fnm + '.' + f)
+
+    # Save individual subplots
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(get_output_dir(
+            parameter.current_set, parameter), parameter.output_file)
+        page = fig.get_size_inches()
+        i = 0
+        for p in panel:
+            # Extent of subplot
+            subpage = np.array(p).reshape(2,2)
+            subpage[1,:] = subpage[0,:] + subpage[1,:]
+            subpage = subpage + np.array(border).reshape(2,2)
+            subpage = list(((subpage)*page).flatten())
+            extent = matplotlib.transforms.Bbox.from_extents(*subpage)
+            # Save suplot
+            fname = fnm + '.%i.' %(i) + f
+            plt.savefig(fname, bbox_inches=extent)
+            _chown(fname, parameter.user)
+            print('Sub-plot saved in: ' + fname)
+            i += 1
+

--- a/acme_diags/plot/cartopy/zonal_mean_xy_plot.py
+++ b/acme_diags/plot/cartopy/zonal_mean_xy_plot.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import os
+import numpy as np
 import numpy.ma as ma
 import matplotlib
 matplotlib.use('Agg')
@@ -11,13 +12,14 @@ from acme_diags.driver.utils import get_output_dir, _chown
 plotTitle = {'fontsize': 12.5}
 plotSideTitle = {'fontsize': 11.5}
 
-# panel = [(0.1691,0.4961,0.6465,0.2258),
-#         (0.1691,0.2112,0.6465,0.2258),
-#         ]
-panel = [(0.1191, 0.5461, 0.6465 * 1.2, 0.2258 * 1.3),
-         (0.1191, 0.1612, 0.6465 * 1.2, 0.2258 * 1.3),
+# Position and sizes of subplot axes in page coordinates (0 to 1)
+panel = [(0.1500, 0.5500, 0.7500, 0.3000),
+         (0.1500, 0.1300, 0.7500, 0.3000),
          ]
 
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+border = (-0.14, -0.06, 0.04, 0.08)
 
 def get_ax_size(fig, ax):
     bbox = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
@@ -29,46 +31,41 @@ def get_ax_size(fig, ax):
 
 def plot(reference, test, diff, metrics_dict, parameter):
 
-    # Create figure, projection
+    # Create figure
     fig = plt.figure(figsize=parameter.figsize, dpi=parameter.dpi)
-    # proj = ccrs.PlateCarree(central_longitude=180)
-    ax = fig.add_axes(panel[0])
-    ax.plot(test.getLatitude()[:], ma.squeeze(test.asma()), 'k', linewidth=2)
 
-    ax.plot(reference.getLatitude()[:], ma.squeeze(
+    # Top panel
+    ax1 = fig.add_axes(panel[0])
+    ax1.plot(test.getLatitude()[:], ma.squeeze(test.asma()), 'k', linewidth=2)
+    ax1.plot(reference.getLatitude()[:], ma.squeeze(
         reference.asma()), 'r', linewidth=2)
-    ax1 = fig.add_axes(panel[1])
-    ax1.plot(diff.getLatitude()[:], ma.squeeze(diff.asma()), 'k', linewidth=2)
-    ax1.axhline(y=0, color='0.5')
+    ax1.set_xticks([-90, -60, -30, 0, 30, 60, 90])
+    ax1.set_xlim(-90, 90)
+    ax1.tick_params(labelsize=11.0, direction='out', width=1)
+    ax1.xaxis.set_ticks_position('bottom')
+    ax1.set_ylabel(test.long_name + ' (' + test.units + ')')
 
     test_title = "Test" if parameter.test_title == '' else parameter.test_title
     test_title += ' : {}'.format(parameter.test_name_yrs)
-    fig.text(panel[0][0], panel[0][2] + 0.095, test_title,
-             ha='left', fontdict=plotSideTitle, color='black')
-
     ref_title = "Reference" if parameter.reference_title == '' else parameter.reference_title
     ref_title += ' : {}'.format(parameter.reference_name)
-    fig.text(panel[0][0], panel[0][2] + 0.07, ref_title,
+    fig.text(panel[0][0], panel[0][1]+panel[0][3]+0.03, test_title,
+             ha='left', fontdict=plotSideTitle, color='black')
+    fig.text(panel[0][0], panel[0][1]+panel[0][3]+0.01, ref_title,
              ha='left', fontdict=plotSideTitle, color='red')
-    fig.text(panel[1][0], panel[0][2] - 0.3, parameter.diff_title,
-             ha='left', fontdict=plotSideTitle)
-    ax.set_xticks([-90, -60, -30, 0, 30, 60, 90])  # crs=ccrs.PlateCarree())
-    ax.set_xlim(-90, 90)
-    ax1.set_xticks([-90, -60, -30, 0, 30, 60, 90])  # crs=ccrs.PlateCarree())
-    ax1.set_xlim(-90, 90)
-    # lon_formatter = LongitudeFormatter(zero_direction_label=True, number_format='.0f')
-    LatitudeFormatter()
-    # ax.xaxis.set_major_formatter(lon_formatter)
-    # ax.xaxis.set_major_formatter(lat_formatter)
-    # ax1.xaxis.set_major_formatter(lat_formatter)
-    ax.tick_params(labelsize=11.0, direction='out', width=1)
-    ax1.tick_params(labelsize=11.0, direction='out', width=1)
-    ax.xaxis.set_ticks_position('bottom')
-    ax1.xaxis.set_ticks_position('bottom')
-    ax.set_ylabel(test.long_name + ' (' + test.units + ')')
-    ax1.set_ylabel(test.long_name + ' (' + test.units + ')')
-    # ax.yaxis.set_ticks_position('left')
 
+    # Bottom panel
+    ax2 = fig.add_axes(panel[1])
+    ax2.plot(diff.getLatitude()[:], ma.squeeze(diff.asma()), 'k', linewidth=2)
+    ax2.axhline(y=0, color='0.5')
+    ax2.set_title(parameter.diff_title, fontdict=plotSideTitle, loc='center') 
+    ax2.set_xticks([-90, -60, -30, 0, 30, 60, 90])
+    ax2.set_xlim(-90, 90)
+    ax2.tick_params(labelsize=11.0, direction='out', width=1)
+    ax2.xaxis.set_ticks_position('bottom')
+    ax2.set_ylabel(test.long_name + ' (' + test.units + ')')
+
+    # Figure title
     fig.suptitle(parameter.main_title, x=0.5, y=0.95, fontsize=18)
 
     # Save figure
@@ -79,3 +76,23 @@ def plot(reference, test, diff, metrics_dict, parameter):
         plt.savefig(fnm + '.' + f)
         _chown(fnm + '.' + f, parameter.user)
         print('Plot saved in: ' + fnm + '.' + f)
+
+    # Save individual subplots
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(get_output_dir(
+            parameter.current_set, parameter), parameter.output_file)
+        page = fig.get_size_inches()
+        i = 0
+        for p in panel:
+            # Extent of subplot
+            subpage = np.array(p).reshape(2,2)
+            subpage[1,:] = subpage[0,:] + subpage[1,:]
+            subpage = subpage + np.array(border).reshape(2,2)
+            subpage = list(((subpage)*page).flatten())
+            extent = matplotlib.transforms.Bbox.from_extents(*subpage)
+            # Save suplot
+            fname = fnm + '.%i.' %(i) + f
+            plt.savefig(fname, bbox_inches=extent)
+            _chown(fname, parameter.user)
+            print('Sub-plot saved in: ' + fname)
+            i += 1


### PR DESCRIPTION
Implements new option to save figures for individual panel plots.

This feature is triggered using a new parameter 'output_format_subplot':

`output_format_subplot = []`
Default behavior, no individual plot files saved.

`output_format_subplot = ['png', 'pdf']`
Individual panel plots saved in png and pdf formats.

Supported plot sets:
- lat_lon
- polar
- zonal_mean_2d
- zonal_mean_xy
- cosp_histogram

Only supported with Matplotlib (mpl) backend. Implementation with VCS left for someone else.
